### PR TITLE
feat!: Add custom baseURL config for resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ require (
 ### Creating and using the flag provider
 
 Below is an example for how to create a OpenFeature client using the Confidence flag provider, and then resolve
-a flag with a boolean attribute. The provider is configured with an api key and a region, which will determine
-where it will send the resolving requests. 
+a flag with a boolean attribute. The provider is configured with an api key for authentication. 
 
 The flag will be applied immediately, meaning that Confidence will count the targeted user as having received the treatment. 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ require (
 ### Creating and using the flag provider
 
 Below is an example for how to create a OpenFeature client using the Confidence flag provider, and then resolve
-a flag with a boolean attribute. The provider is configured with an api key for authentication. 
+a flag with a boolean attribute.
+
+The provider is configured via `APIConfig`, with which you can set the api key for authentication.
+Optionally, a custom resolve API url can be configured if, for example, the resolver service is running on
+a locally deployed side-car.
 
 The flag will be applied immediately, meaning that Confidence will count the targeted user as having received the treatment. 
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ require (
 Below is an example for how to create a OpenFeature client using the Confidence flag provider, and then resolve
 a flag with a boolean attribute.
 
-The provider is configured via `APIConfig`, with which you can set the api key for authentication.
-Optionally, a custom resolve API url can be configured if, for example, the resolver service is running on
-a locally deployed side-car.
+The provider is configured via `NewAPIConfig(...)`, with which you can set the api key for authentication.
+Optionally, a custom resolve API url can be configured if, for example, the resolver service is running on a locally deployed side-car (`NewAPIConfigWithUrl(...)`).
 
 The flag will be applied immediately, meaning that Confidence will count the targeted user as having received the treatment. 
 

--- a/demo/GoDemoApp.go
+++ b/demo/GoDemoApp.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	fmt.Println("Fetching the flags...")
 
-	confidence := c.NewConfidenceBuilder().SetAPIConfig(c.APIConfig{APIKey: "API_KEY"}).Build()
+	confidence := c.NewConfidenceBuilder().SetAPIConfig(*c.NewAPIConfig("API_KEY")).Build()
 	targetingKey := "Random_targeting_key"
 	confidence.PutContext("targeting_key", targetingKey)
 
@@ -34,5 +34,4 @@ func main() {
 	wg := confidence.Track(context.Background(), "page-viewed", map[string]interface{}{})
 	wg.Wait()
 	fmt.Println("Event sent")
-
 }

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -2,4 +2,6 @@ module demo
 
 go 1.22.2
 
-require github.com/spotify/confidence-sdk-go v0.2.2-0.20240523155258-4bbc177010cc
+require github.com/spotify/confidence-sdk-go v0.2.3
+
+replace github.com/spotify/confidence-sdk-go => ../

--- a/demo/go.sum
+++ b/demo/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spotify/confidence-sdk-go v0.2.2-0.20240523155258-4bbc177010cc h1:CyQdom204c6w4UjbT63Otk3axZff4mEbeVDF/snvfas=
 github.com/spotify/confidence-sdk-go v0.2.2-0.20240523155258-4bbc177010cc/go.mod h1:TYBqx3F0AZO7HZF8Nkf2dWnvVHH91ICo0W6e9wmLsk4=
+github.com/spotify/confidence-sdk-go v0.2.3 h1:vJJjWJo6qgpgX+Lg/uiWrtzRw+qaJhwIQRkxwrBJUCA=
+github.com/spotify/confidence-sdk-go v0.2.3/go.mod h1:3MInYY3UiHaNToPlL0mTgbWjcwMMGV/4OfbWAiJ2JC0=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=

--- a/pkg/confidence/confidence.go
+++ b/pkg/confidence/confidence.go
@@ -57,8 +57,8 @@ type ConfidenceBuilder struct {
 
 func (e ConfidenceBuilder) SetAPIConfig(config APIConfig) ConfidenceBuilder {
 	e.confidence.Config = config
-	if config.APIResolveUrl == "" {
-		e.confidence.Config.APIResolveUrl = DefaultAPIResolveUrl
+	if config.APIResolveBaseUrl == "" {
+		e.confidence.Config.APIResolveBaseUrl = DefaultAPIResolveBaseUrl
 	}
 	return e
 }

--- a/pkg/confidence/confidence.go
+++ b/pkg/confidence/confidence.go
@@ -57,6 +57,9 @@ type ConfidenceBuilder struct {
 
 func (e ConfidenceBuilder) SetAPIConfig(config APIConfig) ConfidenceBuilder {
 	e.confidence.Config = config
+	if config.APIResolveUrl == "" {
+		e.confidence.Config.APIResolveUrl = DefaultAPIResolveUrl
+	}
 	return e
 }
 

--- a/pkg/confidence/confidence_context_test.go
+++ b/pkg/confidence/confidence_context_test.go
@@ -97,7 +97,6 @@ func TestChildContextRemoveParentContext(t *testing.T) {
 func create_confidence(t *testing.T, response ResolveResponse) *Confidence {
 	config := APIConfig{
 		APIKey: "apiKey",
-		Region: APIRegionGlobal,
 	}
 	return &Confidence{
 		Config:        config,
@@ -109,7 +108,6 @@ func create_confidence(t *testing.T, response ResolveResponse) *Confidence {
 func createConfidenceWithUploader(t *testing.T, response ResolveResponse, uploader MockEventUploader) *Confidence {
 	config := APIConfig{
 		APIKey: "apiKey",
-		Region: APIRegionGlobal,
 	}
 	return &Confidence{
 		Config:        config,

--- a/pkg/confidence/confidence_internal_test.go
+++ b/pkg/confidence/confidence_internal_test.go
@@ -250,7 +250,6 @@ func emptyResponse() ResolveResponse {
 func newConfidence(apiKey string, client ResolveClient) *Confidence {
 	config := APIConfig{
 		APIKey: apiKey,
-		Region: APIRegionGlobal,
 	}
 	return &Confidence{
 		Config:        config,

--- a/pkg/confidence/http_resolve_client.go
+++ b/pkg/confidence/http_resolve_client.go
@@ -34,7 +34,7 @@ func (client HttpResolveClient) SendResolveRequest(ctx context.Context,
 
 	payload := bytes.NewBuffer(jsonRequest)
 	req, err := http.NewRequestWithContext(ctx,
-		http.MethodPost, fmt.Sprintf("%s/flags:resolve", client.Config.Region.apiURL()), payload)
+		http.MethodPost, fmt.Sprintf("%s/flags:resolve", client.Config.APIResolveUrl), payload)
 	if err != nil {
 		return ResolveResponse{}, err
 	}

--- a/pkg/confidence/http_resolve_client.go
+++ b/pkg/confidence/http_resolve_client.go
@@ -34,7 +34,7 @@ func (client HttpResolveClient) SendResolveRequest(ctx context.Context,
 
 	payload := bytes.NewBuffer(jsonRequest)
 	req, err := http.NewRequestWithContext(ctx,
-		http.MethodPost, fmt.Sprintf("%s/v1/flags:resolve", client.Config.APIResolveUrl), payload)
+		http.MethodPost, fmt.Sprintf("%s/v1/flags:resolve", client.Config.APIResolveBaseUrl), payload)
 	if err != nil {
 		return ResolveResponse{}, err
 	}

--- a/pkg/confidence/http_resolve_client.go
+++ b/pkg/confidence/http_resolve_client.go
@@ -34,7 +34,7 @@ func (client HttpResolveClient) SendResolveRequest(ctx context.Context,
 
 	payload := bytes.NewBuffer(jsonRequest)
 	req, err := http.NewRequestWithContext(ctx,
-		http.MethodPost, fmt.Sprintf("%s/flags:resolve", client.Config.APIResolveUrl), payload)
+		http.MethodPost, fmt.Sprintf("%s/v1/flags:resolve", client.Config.APIResolveUrl), payload)
 	if err != nil {
 		return ResolveResponse{}, err
 	}

--- a/pkg/confidence/models.go
+++ b/pkg/confidence/models.go
@@ -57,20 +57,20 @@ func NewGeneralResolutionError(msg string) ResolutionError {
 }
 
 type APIConfig struct {
-	APIKey string
+	APIKey        string
 	APIResolveUrl string
 }
 
 func NewAPIConfig(apiKey string) *APIConfig {
 	return &APIConfig{
-		APIKey: apiKey,
+		APIKey:        apiKey,
 		APIResolveUrl: "https://resolver.confidence.dev",
 	}
 }
 
 func NewAPIConfigWithUrl(apiKey, apiResolveUrl string) *APIConfig {
 	return &APIConfig{
-		APIKey: apiKey,
+		APIKey:        apiKey,
 		APIResolveUrl: apiResolveUrl,
 	}
 }

--- a/pkg/confidence/models.go
+++ b/pkg/confidence/models.go
@@ -56,6 +56,8 @@ func NewGeneralResolutionError(msg string) ResolutionError {
 	}
 }
 
+const DefaultAPIResolveUrl = "https://resolver.confidence.dev"
+
 type APIConfig struct {
 	APIKey        string
 	APIResolveUrl string
@@ -64,7 +66,7 @@ type APIConfig struct {
 func NewAPIConfig(apiKey string) *APIConfig {
 	return &APIConfig{
 		APIKey:        apiKey,
-		APIResolveUrl: "https://resolver.confidence.dev",
+		APIResolveUrl: DefaultAPIResolveUrl,
 	}
 }
 

--- a/pkg/confidence/models.go
+++ b/pkg/confidence/models.go
@@ -56,24 +56,24 @@ func NewGeneralResolutionError(msg string) ResolutionError {
 	}
 }
 
-const DefaultAPIResolveUrl = "https://resolver.confidence.dev"
+const DefaultAPIResolveBaseUrl = "https://resolver.confidence.dev"
 
 type APIConfig struct {
-	APIKey        string
-	APIResolveUrl string
+	APIKey            string
+	APIResolveBaseUrl string
 }
 
 func NewAPIConfig(apiKey string) *APIConfig {
 	return &APIConfig{
-		APIKey:        apiKey,
-		APIResolveUrl: DefaultAPIResolveUrl,
+		APIKey:            apiKey,
+		APIResolveBaseUrl: DefaultAPIResolveBaseUrl,
 	}
 }
 
-func NewAPIConfigWithUrl(apiKey, apiResolveUrl string) *APIConfig {
+func NewAPIConfigWithUrl(apiKey, APIResolveBaseUrl string) *APIConfig {
 	return &APIConfig{
-		APIKey:        apiKey,
-		APIResolveUrl: apiResolveUrl,
+		APIKey:            apiKey,
+		APIResolveBaseUrl: APIResolveBaseUrl,
 	}
 }
 

--- a/pkg/confidence/models.go
+++ b/pkg/confidence/models.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 )
 
-type APIRegion int64
-
 func NewFlagNotFoundResolutionError(msg string) ResolutionError {
 	return ResolutionError{
 		code:    FlagNotFoundCode,
@@ -60,45 +58,19 @@ func NewGeneralResolutionError(msg string) ResolutionError {
 
 type APIConfig struct {
 	APIKey string
-	Region APIRegion
+	APIResolveUrl string
 }
 
 func NewAPIConfig(apiKey string) *APIConfig {
 	return &APIConfig{
 		APIKey: apiKey,
-		Region: APIRegionGlobal,
+		APIResolveUrl: "https://resolver.confidence.dev/v1",
 	}
-}
-
-const (
-	APIRegionEU     = iota
-	APIRegionUS     = iota
-	APIRegionGlobal = iota
-)
-
-// Private types below
-
-const euAPIURL = "https://resolver.eu.confidence.dev/v1"
-const usAPIURL = "https://resolver.us.confidence.dev/v1"
-const globalAPIURL = "https://resolver.confidence.dev/v1"
-
-func (r APIRegion) apiURL() string {
-	if r == APIRegionEU {
-		return euAPIURL
-	} else if r == APIRegionUS {
-		return usAPIURL
-	} else if r == APIRegionGlobal {
-		return globalAPIURL
-	}
-	return ""
 }
 
 func (c APIConfig) Validate() error {
 	if c.APIKey == "" {
 		return errors.New("api key needs to be set")
-	}
-	if c.Region.apiURL() == "" {
-		return errors.New("api region needs to be set")
 	}
 	return nil
 }

--- a/pkg/confidence/models.go
+++ b/pkg/confidence/models.go
@@ -64,7 +64,14 @@ type APIConfig struct {
 func NewAPIConfig(apiKey string) *APIConfig {
 	return &APIConfig{
 		APIKey: apiKey,
-		APIResolveUrl: "https://resolver.confidence.dev/v1",
+		APIResolveUrl: "https://resolver.confidence.dev",
+	}
+}
+
+func NewAPIConfigWithUrl(apiKey, apiResolveUrl string) *APIConfig {
+	return &APIConfig{
+		APIKey: apiKey,
+		APIResolveUrl: apiResolveUrl,
 	}
 }
 


### PR DESCRIPTION
### Changes
- Add custom baseURL configuration for flag resolve
- Removes the Region selection, now defaulted to the global API Confidence endpoint.
- The Demo App uses the local implementation of the SDK rather than a published version, to facilitate local testing

### How was it tested
This setup has been manually tested with the Demo App both in remote and side-car environments.

### Breaking Changes
- `Region` is now removed, so if the integration is using this configuration it will need to be updated to fix compilation issues 