### PR TITLE
ci: validate against multiple versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19, 1.20, 1.21]
+        go-version: ['1.19', '1.20', '1.21']
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.19', '1.20', '1.21']
+        go-version: ['1.19', '1.20', '1.21', '1.22', '1.23']
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.19, 1.20, 1.21]
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: ${{ matrix.go-version }}
 
       - name: Build Confidence
         run: cd pkg/confidence && go build -v .


### PR DESCRIPTION
Update the Ci to run our build pipelines against multiple go versions.