### PR TITLE
fix: set flag name in resolve debugger link

### DIFF
--- a/pkg/confidence/confidence.go
+++ b/pkg/confidence/confidence.go
@@ -217,11 +217,11 @@ func (e Confidence) ResolveFlag(ctx context.Context, flag string, defaultValue i
 		return processResolveError(err, defaultValue)
 	}
 	key := url.QueryEscape(e.Config.APIKey)
-	flagEncoded := url.QueryEscape(flag)
+	flagEncoded := url.QueryEscape(flagName)
 	json, err := json.Marshal(e.GetContext())
 	if err == nil {
 		jsonContextEncoded := url.QueryEscape(string(json))
-		e.Logger.Debug("See resolves for " + flag + " in Confidence: https://app.confidence.spotify.com/flags/resolver-test?client-key=" + key + "&flag=flags/" + flagEncoded + "&context=" + jsonContextEncoded)
+		e.Logger.Debug("See resolves for " + flagName + " in Confidence: https://app.confidence.spotify.com/flags/resolver-test?client-key=" + key + "&flag=flags/" + flagEncoded + "&context=" + jsonContextEncoded)
 	}
 	if len(resp.ResolvedFlags) == 0 {
 		slog.Debug("Flag not found", "flag", flag)


### PR DESCRIPTION
The Resolve Debugger expects the flag name (not including any dot notation).